### PR TITLE
Add migration file to remove constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ PORT_NUMBER= 3000
 
 ## Front-end
 
-- Next.js (in a separate repo)
+- Svelte (in a separate [repo](https://github.com/amrllkmn/noted-front-end))
 - TailwindCSS

--- a/migrations/20240215123616_remove_unique_constraint.sql
+++ b/migrations/20240215123616_remove_unique_constraint.sql
@@ -1,0 +1,3 @@
+-- Add migration script here
+ALTER TABLE notes
+DROP CONSTRAINT IF EXISTS notes_title_key;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -119,3 +119,13 @@ pub async fn delete_note(
         )
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn dummy_test() {
+        let x = 1;
+        assert_eq!(x, 1);
+    }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -43,7 +43,7 @@ pub async fn get_one_note(pool: &PgPool, note_id: Uuid) -> Result<Note, Error> {
 }
 
 pub async fn get_notes(pool: &PgPool) -> Result<Vec<Note>, Error> {
-    let result = query_as::<_, Note>("SELECT * FROM notes")
+    let result = query_as::<_, Note>("SELECT * FROM notes ORDER BY updated_at DESC;")
         .fetch_all(pool)
         .await;
     match result {
@@ -198,26 +198,6 @@ mod test {
             assert_eq!(note.title, "hello world".to_string());
         }
 
-        Ok(())
-    }
-
-    #[sqlx::test]
-    async fn create_two_notes_with_same_title_should_fail(pool: PgPool) -> sqlx::Result<()> {
-        let new_note = CreateNote {
-            title: "hello world".to_string(),
-            content: "".to_string(),
-        };
-
-        let second_note = CreateNote {
-            title: "hello world".to_string(),
-            content: "".to_string(),
-        };
-
-        let _ = create_note(&pool, new_note).await?;
-
-        let duplicate_note = create_note(&pool, second_note).await;
-
-        assert!(duplicate_note.is_err_and(|err| matches!(err, sqlx::Error::Protocol(_))));
         Ok(())
     }
 


### PR DESCRIPTION
This is to resolve an issue where unique title constraint breaks the app when users accidentally updates their docs to an existing title. E.g:
 
```js
note_1 = {id:1, "title": "Hello", ...}
note_2 = {id: 2, "title": "World", ...}

// Calling PATCH notes/2 with body:
note_2 = {id:2, "title": "Hello",...} // Crashes the app, so this PR aims to fix this issue