### PR TITLE
Use env var to specify front-end url

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
     environment:
       PORT: 3000 # Set the port for your Axum app
       DATABASE_URL: postgres://postgres:postgres@postgres_dev:5432/noted_dev
+      FRONT_END_URL: http://localhost:5173
     depends_on:
       - postgres_dev
     build:

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,10 +1,13 @@
 use crate::handler;
 use axum::{routing::get, Router};
-use http::Method;
+use http::{HeaderValue, Method};
 use sqlx::{Pool, Postgres};
+use std::env;
 use tower_http::cors::{Any, CorsLayer};
 
 pub fn create_api_route(state: Pool<Postgres>) -> Router {
+    let front_end_url: String = env::var("FRONT_END_URL").expect("Missing FRONT_END_URL");
+    let allowed_origin = front_end_url.parse::<HeaderValue>().unwrap();
     let cors = CorsLayer::new()
         // allow `GET` and `POST` when accessing the resource
         .allow_methods([
@@ -15,7 +18,7 @@ pub fn create_api_route(state: Pool<Postgres>) -> Router {
             Method::OPTIONS,
         ])
         // allow requests from any origin
-        .allow_origin(Any);
+        .allow_origin(allowed_origin);
     let api_routes = Router::new()
         .route(
             // GET /notes, POST /notes


### PR DESCRIPTION
We're specifying an env variable for the front-end as previously I allowed any origins to access the back-end (very bad). This should fix the issue